### PR TITLE
Add X11 window capture and hide cursor in captured video

### DIFF
--- a/cmd/doubletake/main.go
+++ b/cmd/doubletake/main.go
@@ -84,7 +84,7 @@ func main() {
 	airplay.DebugMode = *debug
 
 	if *daemonize {
-		runDaemon(*socketPath, *credFile, *credBackend, *fps, *bitrate, *hwaccel, *debug, *testMode, *noEncrypt, *directKey, *noAudio)
+		runDaemon(*socketPath, *credFile, *credBackend, *fps, *bitrate, *hwaccel, *debug, *testMode, *noEncrypt, *directKey, *noAudio, *noCursor)
 		return
 	}
 
@@ -414,7 +414,7 @@ func compareIPs(a, b string) int {
 	return 0
 }
 
-func runDaemon(socketPath, credFile, credBackend string, fps, bitrate int, hwaccel string, debug, testMode, noEncrypt, directKey, noAudio bool) {
+func runDaemon(socketPath, credFile, credBackend string, fps, bitrate int, hwaccel string, debug, testMode, noEncrypt, directKey, noAudio, noCursor bool) {
 	cfg := daemon.Config{
 		SocketPath:  socketPath,
 		CredFile:    credFile,
@@ -427,6 +427,7 @@ func runDaemon(socketPath, credFile, credBackend string, fps, bitrate int, hwacc
 		NoEncrypt:   noEncrypt,
 		DirectKey:   directKey,
 		NoAudio:     noAudio,
+		ShowCursor:  !noCursor,
 	}
 
 	d, err := daemon.New(cfg)

--- a/cmd/doubletake/main.go
+++ b/cmd/doubletake/main.go
@@ -76,6 +76,7 @@ func main() {
 	socketPath := flag.String("socket", daemon.DefaultSocketPath(), "Unix socket path for daemon control interface")
 	x11WindowID := flag.String("x11-window-id", "", "X11 window id to capture, decimal or 0xhex")
 	x11WindowName := flag.String("x11-window-name", "", "X11 window name to capture; prefer -x11-window-id")
+	noCursor := flag.Bool("no-cursor", false, "Don't show the mouse cursor in the captured video")
 	flag.Parse()
 
 	airplay.SetTargetLatency(time.Duration(*targetLatencyMs) * time.Millisecond)
@@ -300,6 +301,7 @@ func main() {
 			HWAccel:       *hwaccel,
 			X11WindowID:   xid,
 			X11WindowName: *x11WindowName,
+			ShowCursor:    !*noCursor,
 		}
 		var err error
 		capture, err = airplay.StartCapture(ctx, captureCfg)

--- a/cmd/doubletake/main.go
+++ b/cmd/doubletake/main.go
@@ -19,6 +19,14 @@ import (
 	"doubletake/internal/daemon"
 )
 
+func parseXID(s string) (uint64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, nil
+	}
+	return strconv.ParseUint(s, 0, 64) // accepts decimal or 0xhex
+}
+
 // parsePortRange parses a "min-max" string into inclusive port bounds.
 // An empty string returns (0, 0, nil) meaning "let the OS pick".
 func parsePortRange(s string) (int, int, error) {
@@ -66,6 +74,8 @@ func main() {
 	debug := flag.Bool("debug", false, "Enable verbose debug logging")
 	daemonize := flag.Bool("daemonize", false, "Run as background daemon with Unix socket control interface")
 	socketPath := flag.String("socket", daemon.DefaultSocketPath(), "Unix socket path for daemon control interface")
+	x11WindowID := flag.String("x11-window-id", "", "X11 window id to capture, decimal or 0xhex")
+	x11WindowName := flag.String("x11-window-name", "", "X11 window name to capture; prefer -x11-window-id")
 	flag.Parse()
 
 	airplay.SetTargetLatency(time.Duration(*targetLatencyMs) * time.Millisecond)
@@ -79,6 +89,11 @@ func main() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	xid, err := parseXID(*x11WindowID)
+	if err != nil {
+		log.Fatalf("invalid -x11-window-id: %v", err)
+	}
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
@@ -280,9 +295,11 @@ func main() {
 		}
 	} else {
 		captureCfg := airplay.CaptureConfig{
-			FPS:     *fps,
-			Bitrate: *bitrate,
-			HWAccel: *hwaccel,
+			FPS:           *fps,
+			Bitrate:       *bitrate,
+			HWAccel:       *hwaccel,
+			X11WindowID:   xid,
+			X11WindowName: *x11WindowName,
 		}
 		var err error
 		capture, err = airplay.StartCapture(ctx, captureCfg)

--- a/internal/airplay/capture.go
+++ b/internal/airplay/capture.go
@@ -24,6 +24,8 @@ type CaptureConfig struct {
 	X11WindowID   uint64
 	X11WindowName string
 
+	ShowCursor bool // show the mouse cursor in the captured video (Wayland and X11)
+
 	RestoreToken     string
 	SaveRestoreToken func(string) error
 }
@@ -73,7 +75,7 @@ func startWaylandCapture(ctx context.Context, cfg CaptureConfig) (*ScreenCapture
 		return nil, fmt.Errorf("GStreamer 'pipewiresrc' plugin not found; install gst-pipewire")
 	}
 
-	nodeID, pwFd, dbusConn, restoreToken, err := requestScreencast(ctx, cfg.RestoreToken)
+	nodeID, pwFd, dbusConn, restoreToken, err := requestScreencast(ctx, cfg.RestoreToken, cfg.ShowCursor)
 	if err != nil {
 		return nil, fmt.Errorf("screencast portal: %w", err)
 	}
@@ -180,7 +182,7 @@ func startX11Capture(ctx context.Context, cfg CaptureConfig) (*ScreenCapture, er
 		"ximagesrc",
 		fmt.Sprintf("display-name=%s", display),
 		"use-damage=false",
-		"show-pointer=false",
+		fmt.Sprintf("show-pointer=%t", cfg.ShowCursor),
 	}
 
 	if cfg.X11WindowID != 0 {
@@ -634,7 +636,7 @@ func vbvBufferKbit(bitrateKbps, fps int) int {
 // permission and returns a PipeWire node ID, an fd for the portal's PipeWire remote,
 // the D-Bus connection (which must stay open to keep the screencast session alive),
 // and a fresh restore token when the portal grants persistence.
-func requestScreencast(ctx context.Context, restoreToken string) (uint32, *os.File, *dbus.Conn, string, error) {
+func requestScreencast(ctx context.Context, restoreToken string, showCursor bool) (uint32, *os.File, *dbus.Conn, string, error) {
 	conn, err := dbus.ConnectSessionBus()
 	if err != nil {
 		return 0, nil, nil, "", fmt.Errorf("connect session bus: %w", err)
@@ -674,12 +676,18 @@ func requestScreencast(ctx context.Context, restoreToken string) (uint32, *os.Fi
 		return 0, nil, nil, "", fmt.Errorf("session handle: %w", err)
 	}
 
+	// cursor_mode: HIDDEN=1, EMBEDDED=2 (cursor baked into the stream)
+	cursorMode := uint32(1)
+	if showCursor {
+		cursorMode = 2
+	}
+
 	// Select sources (screen)
 	selectOpts := map[string]dbus.Variant{
 		"handle_token": dbus.MakeVariant(baseToken + "_select"),
 		"types":        dbus.MakeVariant(uint32(1)), // MONITOR=1, WINDOW=2
 		"multiple":     dbus.MakeVariant(false),
-		"cursor_mode":  dbus.MakeVariant(uint32(2)), // EMBEDDED=2 (cursor in stream)
+		"cursor_mode":  dbus.MakeVariant(cursorMode),
 	}
 	if portalVersion >= 4 {
 		selectOpts["persist_mode"] = dbus.MakeVariant(uint32(2))

--- a/internal/airplay/capture.go
+++ b/internal/airplay/capture.go
@@ -21,6 +21,9 @@ type CaptureConfig struct {
 	Bitrate int    // Video bitrate in kbps (0 = auto)
 	HWAccel string // "auto", "vaapi", "none"
 
+	X11WindowID   uint64
+	X11WindowName string
+
 	RestoreToken     string
 	SaveRestoreToken func(string) error
 }
@@ -52,6 +55,9 @@ type ScreenCapture struct {
 // capture accordingly. On Wayland it uses xdg-desktop-portal + PipeWire for
 // capture; on X11 it uses ximagesrc. Both use GStreamer for H.264 encoding.
 func StartCapture(ctx context.Context, cfg CaptureConfig) (*ScreenCapture, error) {
+	if (cfg.X11WindowID != 0 || cfg.X11WindowName != "") && os.Getenv("DISPLAY") != "" {
+		return startX11Capture(ctx, cfg)
+	}
 	if os.Getenv("WAYLAND_DISPLAY") != "" {
 		return startWaylandCapture(ctx, cfg)
 	}
@@ -170,23 +176,34 @@ func startX11Capture(ctx context.Context, cfg CaptureConfig) (*ScreenCapture, er
 
 	encoder := detectGstEncoder(cfg)
 
-	// Detect primary monitor geometry — ximagesrc captures the full X screen
-	// (all monitors combined). On multi-monitor setups this wastes CPU on pixels
-	// we don't need, so crop to the primary monitor. The encoded resolution is
-	// then the primary monitor's native resolution (no rescaling).
-	startX, startY, endX, endY := detectPrimaryMonitor(display)
-
 	ximageSrcArgs := []string{
-		"ximagesrc", fmt.Sprintf("display-name=%s", display), "use-damage=false",
+		"ximagesrc",
+		fmt.Sprintf("display-name=%s", display),
+		"use-damage=false",
+		"show-pointer=false",
 	}
-	if endX > startX && endY > startY {
-		ximageSrcArgs = append(ximageSrcArgs,
-			fmt.Sprintf("startx=%d", startX),
-			fmt.Sprintf("starty=%d", startY),
-			fmt.Sprintf("endx=%d", endX-1),
-			fmt.Sprintf("endy=%d", endY-1),
-		)
-		dbg("[CAPTURE] cropping ximagesrc to x=%d..%d y=%d..%d", startX, endX-1, startY, endY-1)
+
+	if cfg.X11WindowID != 0 {
+		ximageSrcArgs = append(ximageSrcArgs, fmt.Sprintf("xid=%d", cfg.X11WindowID))
+		dbg("[CAPTURE] capturing X11 window xid=0x%x", cfg.X11WindowID)
+	} else if cfg.X11WindowName != "" {
+		ximageSrcArgs = append(ximageSrcArgs, fmt.Sprintf("xname=%s", cfg.X11WindowName))
+		dbg("[CAPTURE] capturing X11 window name=%q", cfg.X11WindowName)
+	} else {
+		// Detect primary monitor geometry — ximagesrc captures the full X screen
+		// (all monitors combined). On multi-monitor setups this wastes CPU on pixels
+		// we don't need, so crop to the primary monitor. The encoded resolution is
+		// then the primary monitor's native resolution (no rescaling).
+		startX, startY, endX, endY := detectPrimaryMonitor(display)
+		if endX > startX && endY > startY {
+			ximageSrcArgs = append(ximageSrcArgs,
+				fmt.Sprintf("startx=%d", startX),
+				fmt.Sprintf("starty=%d", startY),
+				fmt.Sprintf("endx=%d", endX-1),
+				fmt.Sprintf("endy=%d", endY-1),
+			)
+			dbg("[CAPTURE] cropping ximagesrc to x=%d..%d y=%d..%d", startX, endX-1, startY, endY-1)
+		}
 	}
 
 	gstArgs := []string{"--quiet"}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -80,6 +80,7 @@ type Config struct {
 	NoEncrypt   bool
 	DirectKey   bool
 	NoAudio     bool
+	ShowCursor  bool
 }
 
 // DefaultSocketPath returns the default socket path using XDG_RUNTIME_DIR.
@@ -724,7 +725,7 @@ func (d *Daemon) getOrStartBroadcastLocked(restoreToken, deviceID string) (*airp
 		FPS:          d.cfg.FPS,
 		Bitrate:      d.cfg.Bitrate,
 		HWAccel:      d.cfg.HWAccel,
-		ShowCursor:   true,
+		ShowCursor:   d.cfg.ShowCursor,
 		RestoreToken: restoreToken,
 	}
 	if deviceID != "" {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -724,6 +724,7 @@ func (d *Daemon) getOrStartBroadcastLocked(restoreToken, deviceID string) (*airp
 		FPS:          d.cfg.FPS,
 		Bitrate:      d.cfg.Bitrate,
 		HWAccel:      d.cfg.HWAccel,
+		ShowCursor:   true,
 		RestoreToken: restoreToken,
 	}
 	if deviceID != "" {


### PR DESCRIPTION
Adds -x11-window-id/-x11-window-name flags to capture a single X11 window via ximagesrc's xid/xname properties instead of the whole primary monitor, and sets show-pointer=false so the local mouse cursor doesn't show up in the mirrored stream.