### PR TITLE
capture: improve Wayland capture compatibility on Apple Silicon

### DIFF
--- a/internal/airplay/capture.go
+++ b/internal/airplay/capture.go
@@ -103,8 +103,10 @@ func startWaylandCapture(ctx context.Context, cfg CaptureConfig) (*ScreenCapture
 	// H.264.
 	//   - vapostproc imports the portal's DMA-BUF via VA-API when available
 	//     Systems without VA-API (such as Asahi Linux) fall back to videoconvert.
-	//   - format=I420 forces 4:2:0 — RGB screens otherwise make x264enc emit
-	//     "High 4:4:4 Predictive", which most receiver decoders reject (black).
+	//   - The raw format is pinned to the encoder's required 4:2:0 format. The
+	//     hardware encoders require NV12, while the software encoders use I420.
+	//     Pinning the format also prevents x264enc from emitting High 4:4:4
+	//     Predictive, which most receiver decoders reject (black).
 	//   - videorate re-stamps buffers onto a regular fps timeline: the portal can
 	//     deliver pts=0, which confuses encoder/muxer timing. drop-only=true never
 	//     duplicates frames during idle periods (no wasted bandwidth on a static
@@ -127,11 +129,11 @@ func startWaylandCapture(ctx context.Context, cfg CaptureConfig) (*ScreenCapture
 	}
 
 	gstArgs = append(gstArgs,
-	"!", "videoconvert",
-	"!", "video/x-raw,format=I420",
-	"!", "videorate", "drop-only=true", "skip-to-first=true",
-	"!", fmt.Sprintf("video/x-raw,framerate=%d/1", fps),
-	"!", "queue", "max-size-buffers=1", "max-size-bytes=0", "max-size-time=0", "leaky=downstream",
+		"!", "videoconvert",
+		"!", fmt.Sprintf("video/x-raw,format=%s", encoderParts.rawFormat),
+		"!", "videorate", "drop-only=true", "skip-to-first=true",
+		"!", fmt.Sprintf("video/x-raw,framerate=%d/1", fps),
+		"!", "queue", "max-size-buffers=1", "max-size-bytes=0", "max-size-time=0", "leaky=downstream",
 	)
 	if encoderParts.needsVulkan {
 		gstArgs = append(gstArgs, "!", "vulkanupload")
@@ -235,6 +237,7 @@ func startX11Capture(ctx context.Context, cfg CaptureConfig) (*ScreenCapture, er
 		"!", fmt.Sprintf("video/x-raw,framerate=%d/1", fps),
 		"!", "queue", "max-size-buffers=1", "max-size-bytes=0", "max-size-time=0", "leaky=downstream",
 		"!", "videoconvert",
+		"!", fmt.Sprintf("video/x-raw,format=%s", encoder.rawFormat),
 	)
 	if encoder.needsVulkan {
 		gstArgs = append(gstArgs, "!", "vulkanupload")
@@ -422,7 +425,8 @@ func parseXrandrGeometry(line string) (xOffset, yOffset, width, height int, ok b
 // a vulkanupload step before the encoder.
 type encoderResult struct {
 	parts       []string
-	needsVulkan bool // encoder needs vulkanupload ! before it
+	needsVulkan bool   // encoder needs vulkanupload ! before it
+	rawFormat   string // system-memory format produced by videoconvert
 }
 
 // detectGstEncoder probes for available GStreamer H.264 encoders and returns
@@ -450,6 +454,7 @@ func detectGstEncoder(cfg CaptureConfig) encoderResult {
 					fmt.Sprintf("bitrate=%d", bitrate),
 				},
 				needsVulkan: true,
+				rawFormat:   "NV12",
 			}
 		}
 	}
@@ -458,7 +463,7 @@ func detectGstEncoder(cfg CaptureConfig) encoderResult {
 	if hwaccel == "auto" || hwaccel == "nvenc" {
 		if exec.Command("gst-inspect-1.0", "nvh264enc").Run() == nil {
 			log.Printf("[CAPTURE] using NVENC hardware encoding (nvh264enc)")
-			return encoderResult{parts: []string{
+			return encoderResult{rawFormat: "NV12", parts: []string{
 				"nvh264enc",
 				fmt.Sprintf("bitrate=%d", bitrate),
 				fmt.Sprintf("gop-size=%d", keyframeInterval),
@@ -477,7 +482,7 @@ func detectGstEncoder(cfg CaptureConfig) encoderResult {
 	if hwaccel == "auto" || hwaccel == "vaapi" {
 		if exec.Command("gst-inspect-1.0", "vah264enc").Run() == nil {
 			log.Printf("[CAPTURE] using VAAPI hardware encoding (vah264enc)")
-			return encoderResult{parts: []string{
+			return encoderResult{rawFormat: "NV12", parts: []string{
 				"vah264enc",
 				fmt.Sprintf("bitrate=%d", bitrate),
 				fmt.Sprintf("key-int-max=%d", keyframeInterval),
@@ -496,7 +501,7 @@ func detectGstEncoder(cfg CaptureConfig) encoderResult {
 	// Use VBR (pass=0) so the encoder can undershoot on simple scenes, saving
 	// headroom for complex frames. vbv-buf-capacity + vbv-maxrate cap bursts.
 	maxrate := bitrate + bitrate/4 // allow 25% overshoot on peaks
-	return encoderResult{parts: []string{
+	return encoderResult{rawFormat: "I420", parts: []string{
 		"x264enc",
 		"tune=zerolatency",
 		"speed-preset=superfast",

--- a/internal/airplay/capture.go
+++ b/internal/airplay/capture.go
@@ -69,6 +69,10 @@ func StartCapture(ctx context.Context, cfg CaptureConfig) (*ScreenCapture, error
 	return nil, fmt.Errorf("no display server detected (neither WAYLAND_DISPLAY nor DISPLAY is set)")
 }
 
+func hasGstElement(name string) bool {
+	return exec.Command("gst-inspect-1.0", name).Run() == nil
+}
+
 func startWaylandCapture(ctx context.Context, cfg CaptureConfig) (*ScreenCapture, error) {
 	// Check dependencies
 	if err := exec.Command("gst-inspect-1.0", "pipewiresrc").Run(); err != nil {
@@ -97,8 +101,8 @@ func startWaylandCapture(ctx context.Context, cfg CaptureConfig) (*ScreenCapture
 
 	// Single GStreamer pipeline: capture from the PipeWire portal and encode to
 	// H.264.
-	//   - vapostproc imports the portal's DMA-BUF via VA-API (plain videoconvert
-	//     fails to negotiate DMA-BUF on many drivers, giving a black screen).
+	//   - vapostproc imports the portal's DMA-BUF via VA-API when available
+	//     Systems without VA-API (such as Asahi Linux) fall back to videoconvert.
 	//   - format=I420 forces 4:2:0 — RGB screens otherwise make x264enc emit
 	//     "High 4:4:4 Predictive", which most receiver decoders reject (black).
 	//   - videorate re-stamps buffers onto a regular fps timeline: the portal can
@@ -112,13 +116,23 @@ func startWaylandCapture(ctx context.Context, cfg CaptureConfig) (*ScreenCapture
 	gstArgs := []string{
 		"--quiet",
 		"pipewiresrc", fmt.Sprintf("fd=%d", pwFdNum), fmt.Sprintf("path=%d", nodeID), "do-timestamp=true",
-		"!", "vapostproc",
-		"!", "video/x-raw,format=I420",
-		"!", "videoconvert",
-		"!", "videorate", "drop-only=true", "skip-to-first=true",
-		"!", fmt.Sprintf("video/x-raw,framerate=%d/1", fps),
-		"!", "queue", "max-size-buffers=1", "max-size-bytes=0", "max-size-time=0", "leaky=downstream",
 	}
+
+	if hasGstElement("vapostproc") {
+		gstArgs = append(gstArgs,
+			"!", "vapostproc",
+		)
+	} else {
+		log.Printf("[CAPTURE] vapostproc unavailable, using software conversion")
+	}
+
+	gstArgs = append(gstArgs,
+	"!", "videoconvert",
+	"!", "video/x-raw,format=I420",
+	"!", "videorate", "drop-only=true", "skip-to-first=true",
+	"!", fmt.Sprintf("video/x-raw,framerate=%d/1", fps),
+	"!", "queue", "max-size-buffers=1", "max-size-bytes=0", "max-size-time=0", "leaky=downstream",
+	)
 	if encoderParts.needsVulkan {
 		gstArgs = append(gstArgs, "!", "vulkanupload")
 	}


### PR DESCRIPTION
## Summary

This patch adds a fallback path for Wayland capture on systems without VA-API support.

Previously, the capture pipeline always required `vapostproc`:

```
PipeWire → vapostproc (VA-API) → videoconvert → x264enc → AirPlay
```

On systems like Asahi Linux running on Apple Silicon, `vapostproc` is unavailable, causing capture to fail with:

```
no element "vapostproc"
streaming stopped, reason not-negotiated (-4)
```

The pipeline now uses `vapostproc` when available and falls back to `videoconvert` otherwise:

```
PipeWire → (vapostproc if available) → videoconvert → x264enc → AirPlay
```

## Tested on

* OS: Fedora Linux Asahi Remix 42
* WM: Hyprland 0.55.4 (Wayland)
* Hardware: MacBookAir10,1 (Apple M1)
* TV:  TCL NXTFRAME 55" (55A300W)
* Receiver: TCL/MediaTek AirPlay 2 implementation
* Services: `com.tcl.airplay2`,  `com.mediatek.airplaydaemon `,` com.mediatek.AirplayAPK`
* Hardware: MediaTek platform

Tested:

* AirPlay device discovery
* Pairing
* Wayland screen capture
* H.264 software encoding
* Live mirroring

This may also help address the reported Asahi Linux Wayland black-screen issue, where the AirPlay connection succeeds but screen sharing fails after starting capture, addressed here: #12 . Same thing happened to me. 
