### PR TITLE
Add Support For Password-Protected Receivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ These are devices that have been tested with doubletake. If there are devices no
 - AppleTV3,2 (2013 3rd generation) (currently non-functional, see [#17](https://github.com/omarroth/doubletake/issues/17))
 - AppleTV11,1 (4K, 2021 2nd gen)
 - AppleTV14,1 (4K, 2022 3rd gen) + Homepod (1st gen)
+- AppleTV14,1 (4K, 2022 3rd gen)
 - Mac17,2 (MacBook Pro, M5 14")
 - Mac16,10 (Mac mini, M4)
 - Roku Streaming Stick 4K (3820R2)

--- a/README.md
+++ b/README.md
@@ -119,6 +119,34 @@ sudo ufw allow from any proto tcp to any port 60000:60010
 For nftables/firewalld, add equivalent rules allowing inbound UDP and TCP from
 the Apple TV's address on the chosen range.
 
+## Password-protected receivers
+
+If the receiver has **Require Password** enabled (on an Apple TV: Settings →
+AirPlay and HomeKit), it challenges the mirroring `SETUP` request with HTTP
+Digest auth and mirroring fails with `HTTP 401` until doubletake answers it.
+Pass the password with `-code`:
+
+```sh
+DOUBLETAKE_CODE='...' doubletake -target 192.168.1.77
+```
+
+`-code` carries whatever the receiver is asking for — the onscreen pairing PIN
+during `-pair`, or the fixed password when "Require Password" is enabled.
+`$DOUBLETAKE_CODE` is preferred over the flag: a command line is visible to
+other users via `ps` and lands in shell history. The environment variable takes
+precedence when both are set.
+
+Note that this is separate from pairing. Pairing (`-pair`) authenticates the
+client identity via SRP and saves credentials; the password authenticates
+individual RTSP requests. A receiver may require either, both, or neither.
+Supplying `-code` does not by itself trigger re-pairing.
+
+One thing that makes this confusing to diagnose: **"Require Password" is a
+fixed password you set, not a rotating onscreen code.** Nothing appears on the
+TV during `-pair`, and the prompt is asking for that configured password.
+
+Run with `-debug` to see the challenge and whether the retry was accepted.
+
 ## Usage
 
 ```sh
@@ -168,7 +196,7 @@ doubletake-ctl disconnect
 |------|---------|-------------|
 | `-target` | | Apple TV IP (skip mDNS discovery) |
 | `-port` | 7000 | AirPlay port |
-| `-pin` | | 4-digit PIN for pairing |
+| `-code` | | Pairing PIN shown on the receiver, or its configured password when "Require Password" is enabled (see [Password-protected receivers](#password-protected-receivers)); prefer `$DOUBLETAKE_CODE` |
 | `-cred-backend` | `file` | Credential backend (`file` or `keyring`) |
 | `-creds` | `~/.config/doubletake/credentials.json` | Credentials file path |
 | `-pair` | false | Force new pairing |

--- a/cmd/doubletake/main.go
+++ b/cmd/doubletake/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"flag"
@@ -58,7 +59,7 @@ func parsePortRange(s string) (int, int, error) {
 func main() {
 	target := flag.String("target", "", "Apple TV IP address or hostname (skip discovery)")
 	port := flag.Int("port", 7000, "AirPlay port")
-	pin := flag.String("pin", "", "4-digit PIN for pairing (shown on Apple TV)")
+	pin := flag.String("pin", "", "Pairing PIN or password (an onscreen code, or the password set on the receiver)")
 	credFile := flag.String("creds", airplay.DefaultCredentialsPath(), "Path to saved pairing credentials")
 	credBackend := flag.String("cred-backend", "file", "Credential storage backend: file or keyring (system keyring via Secret Service)")
 	forcePair := flag.Bool("pair", false, "Force new pairing even if credentials exist")
@@ -159,12 +160,7 @@ func main() {
 		// Full pair-setup with PIN
 		pinVal := *pin
 		if pinVal == "" {
-			// Trigger PIN display on the TV first, then ask user
-			if err := client.StartPINDisplay(); err != nil {
-				log.Fatalf("failed to trigger PIN display: %v", err)
-			}
-			fmt.Print("Enter the PIN shown on Apple TV: ")
-			fmt.Scanln(&pinVal)
+			pinVal = promptForPIN(client)
 		}
 		if err := client.Pair(ctx, pinVal); err != nil {
 			log.Fatalf("pairing failed: %v", err)
@@ -349,14 +345,23 @@ func main() {
 	log.Println("stream ended")
 }
 
+// promptForPIN asks the receiver to display a pairing code and reads the user's
+// answer. Receivers configured with a fixed password rather than an onscreen
+// code show nothing at all -- that is not an error, the user simply types the
+// password they set, so a failed pair-pin-start is only a warning.
 func promptForPIN(client *airplay.AirPlayClient) string {
 	if err := client.StartPINDisplay(); err != nil {
 		log.Printf("warning: failed to trigger PIN display: %v", err)
 	}
-	fmt.Print("Enter the PIN shown on Apple TV: ")
-	var pinVal string
-	fmt.Scanln(&pinVal)
-	return pinVal
+	fmt.Print("Enter the code shown on the receiver, or its configured password: ")
+
+	// Read the whole line rather than using fmt.Scanln, which stops at the
+	// first space and would silently truncate a password containing one.
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil && line == "" {
+		log.Printf("warning: failed to read PIN: %v", err)
+	}
+	return strings.TrimRight(line, "\r\n")
 }
 
 func selectDevice(ctx context.Context) (*airplay.AirPlayDevice, error) {

--- a/cmd/doubletake/main.go
+++ b/cmd/doubletake/main.go
@@ -59,7 +59,7 @@ func parsePortRange(s string) (int, int, error) {
 func main() {
 	target := flag.String("target", "", "Apple TV IP address or hostname (skip discovery)")
 	port := flag.Int("port", 7000, "AirPlay port")
-	pin := flag.String("pin", "", "Pairing PIN or password (an onscreen code, or the password set on the receiver)")
+	code := flag.String("code", "", "Pairing PIN shown on the receiver, or the password set on it when \"Require Password\" is enabled; prefer $DOUBLETAKE_CODE so it stays out of shell history and ps output")
 	credFile := flag.String("creds", airplay.DefaultCredentialsPath(), "Path to saved pairing credentials")
 	credBackend := flag.String("cred-backend", "file", "Credential storage backend: file or keyring (system keyring via Secret Service)")
 	forcePair := flag.Bool("pair", false, "Force new pairing even if credentials exist")
@@ -128,7 +128,15 @@ func main() {
 		fmt.Printf("selected: %s (%s:%d)\n", device.Name, device.IP, device.Port)
 	}
 
+	// The environment wins over the flag: it keeps the code out of shell history
+	// and out of `ps`, where a command line is readable by other users.
+	airPlayCode := *code
+	if env := os.Getenv("DOUBLETAKE_CODE"); env != "" {
+		airPlayCode = env
+	}
+
 	client := airplay.NewAirPlayClient(addr, *port)
+	client.SetPassword(airPlayCode)
 	if err := client.Connect(ctx); err != nil {
 		log.Fatalf("connect failed: %v", err)
 	}
@@ -141,10 +149,15 @@ func main() {
 	log.Printf("connected to: %s (model: %s, initialVolume: %.1f)", info.Name, info.Model, info.InitialVolume)
 
 	// Pairing flow:
-	// 1. If --pin provided or --pair forced, do full pair-setup + save credentials
+	// 1. If --pair is forced, do full pair-setup + save credentials
 	// 2. If saved credentials exist, load them and do pair-verify only
 	// 3. Otherwise, do transient (ephemeral) pairing
-	needFullPair := *forcePair || *pin != ""
+	//
+	// -code alone does not force pairing. A receiver with "Require Password"
+	// needs the code on every session, so treating its presence as "pair again"
+	// would re-pair on every run and throw away working credentials. When a
+	// pairing PIN is what is actually wanted, -pair asks for one.
+	needFullPair := *forcePair
 
 	credStore, err := newCredentialStore(*credBackend, *credFile)
 	if err != nil {
@@ -158,10 +171,7 @@ func main() {
 
 	if needFullPair {
 		// Full pair-setup with PIN
-		pinVal := *pin
-		if pinVal == "" {
-			pinVal = promptForPIN(client)
-		}
+		pinVal := codeOrPrompt(airPlayCode, client)
 		if err := client.Pair(ctx, pinVal); err != nil {
 			log.Fatalf("pairing failed: %v", err)
 		}
@@ -191,11 +201,12 @@ func main() {
 				log.Fatalf("get info after reconnect failed: %v", err)
 			}
 			if err := client.Pair(ctx, ""); err != nil {
-				log.Printf("transient pairing fallback failed: %v, prompting for PIN", err)
-				pinVal := promptForPIN(client)
+				log.Printf("transient pairing fallback failed: %v, pairing with a code", err)
+				pinVal := codeOrPrompt(airPlayCode, client)
 				// Reconnect for fresh PIN pairing attempt
 				client.Close()
 				client = airplay.NewAirPlayClient(addr, *port)
+				client.SetPassword(airPlayCode)
 				if err := client.Connect(ctx); err != nil {
 					log.Fatalf("reconnect failed: %v", err)
 				}
@@ -216,11 +227,12 @@ func main() {
 	} else {
 		// Transient pairing (no saved creds, no PIN)
 		if err := client.Pair(ctx, ""); err != nil {
-			log.Printf("transient pairing failed: %v, prompting for PIN", err)
-			pinVal := promptForPIN(client)
+			log.Printf("transient pairing failed: %v, pairing with a code", err)
+			pinVal := codeOrPrompt(airPlayCode, client)
 			// Reconnect for fresh PIN pairing attempt
 			client.Close()
 			client = airplay.NewAirPlayClient(addr, *port)
+			client.SetPassword(airPlayCode)
 			if err := client.Connect(ctx); err != nil {
 				log.Fatalf("reconnect failed: %v", err)
 			}
@@ -259,13 +271,13 @@ func main() {
 		log.Fatalf("invalid -port-range: %v", err)
 	}
 	streamCfg := airplay.StreamConfig{
-		FPS:       *fps,
-		Bitrate:   *bitrate,
-		NoEncrypt: *noEncrypt,
-		DirectKey: *directKey,
-		NoAudio:   *noAudio,
-		PortMin:   portMin,
-		PortMax:   portMax,
+		FPS:            *fps,
+		Bitrate:        *bitrate,
+		NoEncrypt:      *noEncrypt,
+		DirectKey:      *directKey,
+		NoAudio:        *noAudio,
+		PortMin:        portMin,
+		PortMax:        portMax,
 	}
 	session, err := client.SetupMirror(ctx, streamCfg)
 	if err != nil {
@@ -343,6 +355,17 @@ func main() {
 		log.Fatalf("streaming error: %v", err)
 	}
 	log.Println("stream ended")
+}
+
+// codeOrPrompt uses the code supplied on the command line if there is one, and
+// otherwise asks for it interactively. The same value serves as the pairing PIN
+// and as the password for Digest auth, so a user who supplied one is never
+// asked for it again mid-run.
+func codeOrPrompt(code string, client *airplay.AirPlayClient) string {
+	if code != "" {
+		return code
+	}
+	return promptForPIN(client)
 }
 
 // promptForPIN asks the receiver to display a pairing code and reads the user's

--- a/internal/airplay/client.go
+++ b/internal/airplay/client.go
@@ -8,8 +8,10 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"strings"
 	"sync"
@@ -110,6 +112,15 @@ type AirPlayClient struct {
 	// Stream encryption key (from FP or pair-verify)
 	streamKey []byte
 	streamIV  []byte
+
+	// HTTP Digest credentials, used only when the receiver has "Require
+	// Password" enabled and challenges a request with 401. Separate from
+	// pairing: pair-setup authenticates the client identity, this
+	// authenticates individual requests.
+	authPassword string
+	// Most recent Digest challenge seen on this connection. Cached so later
+	// requests can authenticate up front instead of relying on a retry.
+	authChallenge *digestChallenge
 }
 
 func NewAirPlayClient(host string, port int) *AirPlayClient {
@@ -119,6 +130,88 @@ func NewAirPlayClient(host string, port int) *AirPlayClient {
 		sessionID: generateUUID(),
 		PairingID: generateUUID(),
 	}
+}
+
+// SetPassword configures the password used to answer HTTP Digest challenges
+// from receivers with "Require Password" enabled. An empty password leaves
+// authentication disabled and 401s surface to the caller unchanged.
+func (c *AirPlayClient) SetPassword(password string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.authPassword = password
+}
+
+// digestRetryHeader returns an Authorization header value when err is a 401
+// carrying a Digest challenge we hold credentials for. Callers retry at most
+// once: if the authenticated request is rejected too, that error surfaces
+// rather than looping.
+//
+// Must be called with c.mu held.
+func (c *AirPlayClient) digestRetryHeader(method, uri string, respHeaders map[string]string, err error) (string, bool) {
+	if err == nil {
+		return "", false
+	}
+	var statusErr *HTTPStatusError
+	if !errors.As(err, &statusErr) || statusErr.StatusCode != 401 {
+		return "", false
+	}
+
+	// Indexing a nil map is fine; a 401 without the header just means we
+	// cannot answer it.
+	ch, ok := parseDigestChallenge(respHeaders["www-authenticate"])
+	if !ok {
+		log.Printf("warning: %s %s was rejected with 401 but sent no Digest challenge to answer", method, uri)
+		return "", false
+	}
+	// Cache it even when we cannot answer right now, so the rest of the session
+	// authenticates up front: a receiver that challenges one request challenges
+	// them all, and a mirroring session issues around two dozen.
+	c.authChallenge = ch
+
+	// Say so loudly rather than letting an opaque 401 surface: a challenge we
+	// have no password for is the single most likely reason mirroring fails
+	// against a receiver with "Require Password" enabled.
+	if c.authPassword == "" {
+		log.Printf("%s %s needs a code: the receiver sent a Digest challenge (realm=%q)", method, uri, ch.Realm)
+		log.Printf("  set $DOUBLETAKE_CODE (or -code) to the password configured on the receiver")
+		return "", false
+	}
+
+	return authorizationHeader(DigestUsername, c.authPassword, ch, method, uri), true
+}
+
+// preemptiveAuthHeader returns an Authorization header built from the cached
+// challenge, so a request that already knows it will be challenged answers up
+// front rather than being sent twice.
+//
+// Must be called with c.mu held.
+func (c *AirPlayClient) preemptiveAuthHeader(method, uri string) (string, bool) {
+	if c.authPassword == "" || c.authChallenge == nil {
+		return "", false
+	}
+	return authorizationHeader(DigestUsername, c.authPassword, c.authChallenge, method, uri), true
+}
+
+// logIfAuthRejected reports a second 401 distinctly from the first. Reaching
+// here means a password was sent and refused -- a different problem from
+// having none at all.
+func (c *AirPlayClient) logIfAuthRejected(method, uri string, err error) {
+	var statusErr *HTTPStatusError
+	if errors.As(err, &statusErr) && statusErr.StatusCode == 401 {
+		log.Printf("%s %s: receiver rejected the code (Digest username %q)", method, uri, DigestUsername)
+	}
+}
+
+// withHeader returns a copy of hdrs with key set. Call sites reuse their header
+// maps across requests, so mutating the original would leak a stale nonce into
+// later ones.
+func withHeader(hdrs map[string]string, key, value string) map[string]string {
+	out := make(map[string]string, len(hdrs)+1)
+	for k, v := range hdrs {
+		out[k] = v
+	}
+	out[key] = value
+	return out
 }
 
 func (c *AirPlayClient) Connect(ctx context.Context) error {
@@ -195,6 +288,22 @@ func (c *AirPlayClient) httpRequest(method, path, contentType string, body []byt
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if authHdr, ok := c.preemptiveAuthHeader(method, path); ok {
+		dbg("[HTTP] authenticating %s %s up front from the cached challenge", method, path)
+		extraHeaders = append(append([]map[string]string{}, extraHeaders...), map[string]string{"Authorization": authHdr})
+	}
+
+	respBody, respHeaders, err := c.httpRequestOnce(method, path, contentType, body, extraHeaders...)
+	if authHdr, ok := c.digestRetryHeader(method, path, respHeaders, err); ok {
+		dbg("[HTTP] 401 digest challenge on %s %s, retrying with credentials", method, path)
+		retry := append(append([]map[string]string{}, extraHeaders...), map[string]string{"Authorization": authHdr})
+		respBody, _, err = c.httpRequestOnce(method, path, contentType, body, retry...)
+		c.logIfAuthRejected(method, path, err)
+	}
+	return respBody, err
+}
+
+func (c *AirPlayClient) httpRequestOnce(method, path, contentType string, body []byte, extraHeaders ...map[string]string) ([]byte, map[string]string, error) {
 	seq := c.cseq.Add(1)
 
 	var buf bytes.Buffer
@@ -223,15 +332,11 @@ func (c *AirPlayClient) httpRequest(method, path, contentType string, body []byt
 	}
 
 	if _, err := c.conn.Write(data); err != nil {
-		return nil, fmt.Errorf("write request: %w", err)
+		return nil, nil, fmt.Errorf("write request: %w", err)
 	}
 	dbg("[HTTP] wrote %d bytes to socket, waiting for response...", len(data))
 
-	resp, _, err := c.readHTTPResponse()
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return c.readHTTPResponse()
 }
 
 // rawRequest sends a bare RTSP/1.0 request without X-Apple-Session-ID or HAP
@@ -276,6 +381,21 @@ func (c *AirPlayClient) rtspRequest(method, uri, contentType string, body []byte
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if authHdr, ok := c.preemptiveAuthHeader(method, uri); ok {
+		dbg("[RTSP] authenticating %s %s up front from the cached challenge", method, uri)
+		extraHeaders = withHeader(extraHeaders, "Authorization", authHdr)
+	}
+
+	respBody, respHeaders, err := c.rtspRequestOnce(method, uri, contentType, body, extraHeaders)
+	if authHdr, ok := c.digestRetryHeader(method, uri, respHeaders, err); ok {
+		dbg("[RTSP] 401 digest challenge on %s %s, retrying with credentials", method, uri)
+		respBody, respHeaders, err = c.rtspRequestOnce(method, uri, contentType, body, withHeader(extraHeaders, "Authorization", authHdr))
+		c.logIfAuthRejected(method, uri, err)
+	}
+	return respBody, respHeaders, err
+}
+
+func (c *AirPlayClient) rtspRequestOnce(method, uri, contentType string, body []byte, extraHeaders map[string]string) ([]byte, map[string]string, error) {
 	seq := c.cseq.Add(1)
 
 	var buf bytes.Buffer
@@ -310,7 +430,10 @@ func (c *AirPlayClient) rtspRequest(method, uri, contentType string, body []byte
 
 	respBody, respHeaders, err := c.readHTTPResponse()
 	if err != nil {
-		return nil, nil, err
+		// Return the headers even on failure: a 401 carries its
+		// WWW-Authenticate challenge there, and dropping them makes an
+		// answerable challenge look like an unanswerable one.
+		return nil, respHeaders, err
 	}
 
 	dbg("[RTSP] <- response body %d bytes", len(respBody))

--- a/internal/airplay/digest.go
+++ b/internal/airplay/digest.go
@@ -1,0 +1,112 @@
+package airplay
+
+import (
+	"crypto/md5" //nolint:gosec // MD5 is what RFC 2069 digest auth specifies; not our choice.
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// DigestUsername is the username AirPlay receivers expect in a Digest response.
+// The challenge never carries a username, but it is folded into HA1, so a wrong
+// value fails exactly like a wrong password: another 401. Receivers advertising
+// realm="airplay" -- which is what a mirroring receiver advertises -- use
+// "AirPlay".
+const DigestUsername = "AirPlay"
+
+// digestChallenge is a parsed WWW-Authenticate Digest challenge.
+type digestChallenge struct {
+	Realm string
+	Nonce string
+}
+
+// parseDigestChallenge parses a WWW-Authenticate header value of the form
+//
+//	Digest realm="airplay", nonce="MTc4NTE4NjAxMCD20F7TBLQS+AiSlk1YQmKR"
+//
+// Apple TV sends neither qop nor algorithm, so this is the RFC 2069 flavour of
+// digest rather than the RFC 2617 qop="auth" variant: no cnonce, no nc, and
+// the response is a plain MD5(HA1:nonce:HA2).
+func parseDigestChallenge(value string) (*digestChallenge, bool) {
+	const scheme = "Digest"
+	v := strings.TrimSpace(value)
+	if len(v) < len(scheme) || !strings.EqualFold(v[:len(scheme)], scheme) {
+		return nil, false
+	}
+
+	params := parseAuthParams(v[len(scheme):])
+	realm, hasRealm := params["realm"]
+	nonce, hasNonce := params["nonce"]
+	if !hasRealm || !hasNonce {
+		return nil, false
+	}
+	return &digestChallenge{Realm: realm, Nonce: nonce}, true
+}
+
+// parseAuthParams splits a comma-separated list of key="value" (or bare
+// key=value) auth parameters. Quoted values are unquoted, and a comma inside
+// quotes is kept rather than treated as a separator -- nonces are base64 and
+// can contain characters that would otherwise confuse a naive split.
+func parseAuthParams(s string) map[string]string {
+	params := make(map[string]string)
+
+	var key, val strings.Builder
+	inKey, inQuotes := true, false
+
+	flush := func() {
+		k := strings.ToLower(strings.TrimSpace(key.String()))
+		if k != "" {
+			params[k] = strings.TrimSpace(val.String())
+		}
+		key.Reset()
+		val.Reset()
+		inKey = true
+	}
+
+	for i := 0; i < len(s); i++ {
+		switch ch := s[i]; {
+		case inQuotes && ch == '"':
+			inQuotes = false
+		case inQuotes:
+			val.WriteByte(ch)
+		case ch == '"' && !inKey:
+			inQuotes = true
+		case ch == '=' && inKey:
+			inKey = false
+		case ch == ',':
+			flush()
+		case inKey:
+			key.WriteByte(ch)
+		default:
+			val.WriteByte(ch)
+		}
+	}
+	flush()
+
+	return params
+}
+
+// digestResponse computes the RFC 2069 digest response:
+//
+//	HA1      = MD5(username:realm:password)
+//	HA2      = MD5(method:uri)
+//	response = MD5(HA1:nonce:HA2)
+func digestResponse(username, realm, password, nonce, method, uri string) string {
+	ha1 := md5Hex(username + ":" + realm + ":" + password)
+	ha2 := md5Hex(method + ":" + uri)
+	return md5Hex(ha1 + ":" + nonce + ":" + ha2)
+}
+
+func md5Hex(s string) string {
+	sum := md5.Sum([]byte(s)) //nolint:gosec // see file header
+	return hex.EncodeToString(sum[:])
+}
+
+// authorizationHeader builds the Authorization header value that answers ch.
+func authorizationHeader(username, password string, ch *digestChallenge, method, uri string) string {
+	return fmt.Sprintf(
+		`Digest username="%s", realm="%s", nonce="%s", uri="%s", response="%s"`,
+		username, ch.Realm, ch.Nonce, uri,
+		digestResponse(username, ch.Realm, password, ch.Nonce, method, uri),
+	)
+}

--- a/internal/airplay/digest_auth_test.go
+++ b/internal/airplay/digest_auth_test.go
@@ -1,0 +1,277 @@
+package airplay
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRTSPRequestAnswersDigestChallenge drives rtspRequest against a fake
+// receiver that behaves like an Apple TV with "Require Password" enabled: the
+// first request is refused with a Digest challenge, and only a request bearing
+// a matching Authorization header succeeds.
+//
+// This is the end-to-end guard for the retry. A unit test of digestRetryHeader
+// alone passes even when rtspRequestOnce drops the response headers on its
+// error path, which makes an answerable challenge look unanswerable.
+func TestRTSPRequestAnswersDigestChallenge(t *testing.T) {
+	const (
+		password = "s3cr3t"
+		realm    = "airplay"
+		nonce    = "MTc4NTE4NzY0NyAdeqAzeNIhSe0923w+y6HS"
+		uri      = "rtsp://127.0.0.1/stream"
+	)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	type result struct {
+		requests []rtspTestRequest
+		err      error
+	}
+	done := make(chan result, 1)
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			done <- result{err: err}
+			return
+		}
+		defer conn.Close()
+
+		var seen []rtspTestRequest
+		reader := bufio.NewReader(conn)
+
+		// First request: refuse with a challenge.
+		req, err := readRTSPTestRequest(reader)
+		if err != nil {
+			done <- result{err: err}
+			return
+		}
+		seen = append(seen, req)
+		if err := writeRTSPTestResponse(conn, 401, map[string]string{
+			"WWW-Authenticate": `Digest realm="` + realm + `", nonce="` + nonce + `"`,
+		}, nil); err != nil {
+			done <- result{err: err}
+			return
+		}
+
+		// Second request: accept only if it carries the right response.
+		req, err = readRTSPTestRequest(reader)
+		if err != nil {
+			done <- result{err: err}
+			return
+		}
+		seen = append(seen, req)
+
+		want := digestResponse(DigestUsername, realm, password, nonce, "SETUP", uri)
+		status := 401
+		if strings.Contains(req.headers["authorization"], `response="`+want+`"`) {
+			status = 200
+		}
+		err = writeRTSPTestResponse(conn, status, nil, []byte("ok"))
+		done <- result{requests: seen, err: err}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client := NewAirPlayClient("127.0.0.1", listener.Addr().(*net.TCPAddr).Port)
+	client.SetPassword(password)
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer client.Close()
+
+	body, _, err := client.rtspRequest("SETUP", uri, "text/plain", []byte("x"), nil)
+	if err != nil {
+		t.Fatalf("rtspRequest: expected the retry to succeed, got %v", err)
+	}
+	if string(body) != "ok" {
+		t.Errorf("body = %q, want %q", body, "ok")
+	}
+
+	res := <-done
+	if res.err != nil {
+		t.Fatalf("fake receiver: %v", res.err)
+	}
+	if len(res.requests) != 2 {
+		t.Fatalf("receiver saw %d requests, want 2 (challenge then retry)", len(res.requests))
+	}
+	if got := res.requests[0].headers["authorization"]; got != "" {
+		t.Errorf("first request should be unauthenticated, carried Authorization: %q", got)
+	}
+	if got := res.requests[1].headers["authorization"]; !strings.HasPrefix(got, "Digest ") {
+		t.Errorf("retry Authorization = %q, want a Digest header", got)
+	}
+}
+
+// TestRTSPRequestWithoutPasswordDoesNotRetry checks that an unconfigured
+// password leaves the 401 to surface rather than retrying blindly.
+func TestRTSPRequestWithoutPasswordDoesNotRetry(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	count := make(chan int, 1)
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			count <- -1
+			return
+		}
+		defer conn.Close()
+
+		reader := bufio.NewReader(conn)
+		n := 0
+		for {
+			if _, err := readRTSPTestRequest(reader); err != nil {
+				count <- n
+				return
+			}
+			n++
+			if err := writeRTSPTestResponse(conn, 401, map[string]string{
+				"WWW-Authenticate": `Digest realm="airplay", nonce="abc"`,
+			}, nil); err != nil {
+				count <- n
+				return
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client := NewAirPlayClient("127.0.0.1", listener.Addr().(*net.TCPAddr).Port)
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	if _, _, err := client.rtspRequest("SETUP", "rtsp://127.0.0.1/stream", "text/plain", []byte("x"), nil); err == nil {
+		t.Fatal("expected the 401 to surface when no password is configured")
+	}
+	client.Close()
+
+	if n := <-count; n != 1 {
+		t.Errorf("receiver saw %d requests, want exactly 1 (no retry without a password)", n)
+	}
+}
+
+// TestCachedChallengeAuthenticatesLaterRequests checks that only the first
+// request on a connection pays for the retry. A mirroring session issues around
+// two dozen requests, and a receiver that challenges one challenges them all, so
+// the nonce is cached on first sight and reused up front from then on.
+func TestCachedChallengeAuthenticatesLaterRequests(t *testing.T) {
+	const (
+		password = "s3cr3t"
+		realm    = "airplay"
+		nonce    = "cachedNonce123"
+		setupURI = "rtsp://127.0.0.1/stream"
+	)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	type result struct {
+		requests []rtspTestRequest
+		err      error
+	}
+	done := make(chan result, 1)
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			done <- result{err: err}
+			return
+		}
+		defer conn.Close()
+
+		var seen []rtspTestRequest
+		reader := bufio.NewReader(conn)
+		for {
+			req, err := readRTSPTestRequest(reader)
+			if err != nil {
+				done <- result{requests: seen, err: nil}
+				return
+			}
+			seen = append(seen, req)
+
+			// A password-protected receiver challenges every unauthenticated
+			// request, whatever the method.
+			want := digestResponse(DigestUsername, realm, password, nonce, req.method, setupURI)
+			if !strings.Contains(req.headers["authorization"], `response="`+want+`"`) {
+				if err := writeRTSPTestResponse(conn, 401, map[string]string{
+					"WWW-Authenticate": `Digest realm="` + realm + `", nonce="` + nonce + `"`,
+				}, nil); err != nil {
+					done <- result{requests: seen, err: err}
+					return
+				}
+				continue
+			}
+			if err := writeRTSPTestResponse(conn, 200, nil, []byte("ok")); err != nil {
+				done <- result{requests: seen, err: err}
+				return
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client := NewAirPlayClient("127.0.0.1", listener.Addr().(*net.TCPAddr).Port)
+	client.SetPassword(password)
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	// First request on the connection: challenged, then retried with credentials.
+	if _, _, err := client.rtspRequest("SETUP", setupURI, "text/plain", []byte("x"), nil); err != nil {
+		t.Fatalf("SETUP: %v", err)
+	}
+	// Second request: the nonce is known, so this must not be challenged again.
+	body, _, err := client.rtspRequest("RECORD", setupURI, "", nil, nil)
+	if err != nil {
+		t.Fatalf("RECORD: %v", err)
+	}
+	if string(body) != "ok" {
+		t.Errorf("body = %q, want %q", body, "ok")
+	}
+	client.Close()
+
+	res := <-done
+	if res.err != nil {
+		t.Fatalf("fake receiver: %v", res.err)
+	}
+
+	var methods []string
+	for _, r := range res.requests {
+		methods = append(methods, r.method)
+	}
+	want := []string{"SETUP", "SETUP", "RECORD"}
+	if len(methods) != len(want) {
+		t.Fatalf("receiver saw %v, want %v (RECORD must not be sent twice)", methods, want)
+	}
+	for i := range want {
+		if methods[i] != want[i] {
+			t.Fatalf("receiver saw %v, want %v", methods, want)
+		}
+	}
+	if auth := res.requests[0].headers["authorization"]; auth != "" {
+		t.Errorf("first SETUP carried an Authorization header %q; there was no nonce to build it from yet", auth)
+	}
+	if auth := res.requests[2].headers["authorization"]; !strings.HasPrefix(auth, "Digest ") {
+		t.Errorf("RECORD went out unauthenticated (%q); the cached challenge should have covered it", auth)
+	}
+}

--- a/internal/airplay/digest_test.go
+++ b/internal/airplay/digest_test.go
@@ -1,0 +1,192 @@
+package airplay
+
+import "testing"
+
+func TestParseDigestChallenge(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		wantOK    bool
+		wantRealm string
+		wantNonce string
+	}{
+		{
+			// Verbatim from an AppleTV14,1 running AirTunes/950.7.1 with
+			// "Require Password" enabled: no qop, no algorithm, base64 nonce.
+			name:      "apple tv challenge",
+			value:     `Digest realm="airplay", nonce="MTc4NTE4NjAxMCD20F7TBLQS+AiSlk1YQmKR"`,
+			wantOK:    true,
+			wantRealm: "airplay",
+			wantNonce: "MTc4NTE4NjAxMCD20F7TBLQS+AiSlk1YQmKR",
+		},
+		{
+			name:      "raop realm",
+			value:     `Digest realm="raop", nonce="deadbeef"`,
+			wantOK:    true,
+			wantRealm: "raop",
+			wantNonce: "deadbeef",
+		},
+		{
+			name:      "lowercase scheme and extra whitespace",
+			value:     `  digest   realm="airplay" ,  nonce="abc"  `,
+			wantOK:    true,
+			wantRealm: "airplay",
+			wantNonce: "abc",
+		},
+		{
+			// A comma inside a quoted value must not split the parameter.
+			name:      "comma inside quoted nonce",
+			value:     `Digest realm="airplay", nonce="aa,bb", algorithm=MD5`,
+			wantOK:    true,
+			wantRealm: "airplay",
+			wantNonce: "aa,bb",
+		},
+		{
+			name:   "basic scheme is not digest",
+			value:  `Basic realm="airplay"`,
+			wantOK: false,
+		},
+		{
+			name:   "missing nonce",
+			value:  `Digest realm="airplay"`,
+			wantOK: false,
+		},
+		{
+			name:   "missing realm",
+			value:  `Digest nonce="abc"`,
+			wantOK: false,
+		},
+		{
+			// What a 401 with no WWW-Authenticate header looks like after a
+			// nil-map lookup.
+			name:   "empty",
+			value:  "",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ch, ok := parseDigestChallenge(tt.value)
+			if ok != tt.wantOK {
+				t.Fatalf("parseDigestChallenge(%q) ok = %v, want %v", tt.value, ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if ch.Realm != tt.wantRealm {
+				t.Errorf("realm = %q, want %q", ch.Realm, tt.wantRealm)
+			}
+			if ch.Nonce != tt.wantNonce {
+				t.Errorf("nonce = %q, want %q", ch.Nonce, tt.wantNonce)
+			}
+		})
+	}
+}
+
+func TestDigestResponse(t *testing.T) {
+	// Expected value computed independently:
+	//   HA1      = md5("AirPlay:airplay:secret")
+	//   HA2      = md5("SETUP:rtsp://192.168.1.246/1234")
+	//   response = md5(HA1:abc123:HA2)
+	const want = "62160c3ff2f72dacd546c8c5135eba4b"
+
+	got := digestResponse("AirPlay", "airplay", "secret", "abc123", "SETUP", "rtsp://192.168.1.246/1234")
+	if got != want {
+		t.Errorf("digestResponse() = %q, want %q", got, want)
+	}
+}
+
+func TestDigestResponseVariesWithCredentials(t *testing.T) {
+	base := digestResponse("AirPlay", "airplay", "secret", "abc123", "SETUP", "rtsp://host/1")
+
+	// The username is folded into HA1, so getting it wrong fails exactly like a
+	// wrong password -- which is why DigestUsername is fixed rather than
+	// guessed: a bad guess is indistinguishable from a bad password.
+	if other := digestResponse("iTunes", "airplay", "secret", "abc123", "SETUP", "rtsp://host/1"); other == base {
+		t.Error("response did not change with a different username")
+	}
+	if other := digestResponse("AirPlay", "airplay", "wrong", "abc123", "SETUP", "rtsp://host/1"); other == base {
+		t.Error("response did not change with a different password")
+	}
+	// HA2 covers method and URI, so a replayed header cannot authorise a
+	// different request.
+	if other := digestResponse("AirPlay", "airplay", "secret", "abc123", "RECORD", "rtsp://host/1"); other == base {
+		t.Error("response did not change with a different method")
+	}
+	if other := digestResponse("AirPlay", "airplay", "secret", "abc123", "SETUP", "rtsp://host/2"); other == base {
+		t.Error("response did not change with a different uri")
+	}
+	if other := digestResponse("AirPlay", "airplay", "secret", "different", "SETUP", "rtsp://host/1"); other == base {
+		t.Error("response did not change with a different nonce")
+	}
+}
+
+func TestAuthorizationHeader(t *testing.T) {
+	ch := &digestChallenge{Realm: "airplay", Nonce: "abc123"}
+	got := authorizationHeader("AirPlay", "secret", ch, "SETUP", "rtsp://192.168.1.246/1234")
+	want := `Digest username="AirPlay", realm="airplay", nonce="abc123", uri="rtsp://192.168.1.246/1234", ` +
+		`response="` + digestResponse("AirPlay", "airplay", "secret", "abc123", "SETUP", "rtsp://192.168.1.246/1234") + `"`
+	if got != want {
+		t.Errorf("authorizationHeader() =\n  %q\nwant\n  %q", got, want)
+	}
+}
+
+func TestWithHeaderDoesNotMutateOriginal(t *testing.T) {
+	original := map[string]string{"X-Existing": "1"}
+	out := withHeader(original, "Authorization", "Digest ...")
+
+	if _, ok := original["Authorization"]; ok {
+		t.Error("withHeader mutated the caller's map; a stale nonce would leak into later requests")
+	}
+	if out["X-Existing"] != "1" || out["Authorization"] != "Digest ..." {
+		t.Errorf("withHeader produced %v", out)
+	}
+	if nilOut := withHeader(nil, "Authorization", "x"); nilOut["Authorization"] != "x" {
+		t.Error("withHeader did not handle a nil map")
+	}
+}
+
+func TestDigestRetryHeader(t *testing.T) {
+	challenge := map[string]string{
+		"www-authenticate": `Digest realm="airplay", nonce="abc123"`,
+	}
+	unauthorized := &HTTPStatusError{StatusCode: 401}
+
+	tests := []struct {
+		name     string
+		password string
+		headers  map[string]string
+		err      error
+		wantOK   bool
+	}{
+		{name: "success is not retried", password: "secret", headers: challenge, err: nil, wantOK: false},
+		{name: "non-401 is not retried", password: "secret", headers: challenge, err: &HTTPStatusError{StatusCode: 500}, wantOK: false},
+		{
+			// The case that silently did nothing before: a challenge arrives,
+			// no password is configured, and the bare 401 surfaces.
+			name: "401 with challenge but no password", password: "", headers: challenge, err: unauthorized, wantOK: false,
+		},
+		{name: "401 without a challenge header", password: "secret", headers: map[string]string{}, err: unauthorized, wantOK: false},
+		{name: "401 with nil headers", password: "secret", headers: nil, err: unauthorized, wantOK: false},
+		{name: "401 with challenge and password", password: "secret", headers: challenge, err: unauthorized, wantOK: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &AirPlayClient{authPassword: tt.password}
+			hdr, ok := c.digestRetryHeader("SETUP", "rtsp://host/1", tt.headers, tt.err)
+			if ok != tt.wantOK {
+				t.Fatalf("digestRetryHeader ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			want := authorizationHeader(DigestUsername, tt.password,
+				&digestChallenge{Realm: "airplay", Nonce: "abc123"}, "SETUP", "rtsp://host/1")
+			if hdr != want {
+				t.Errorf("header =\n  %q\nwant\n  %q", hdr, want)
+			}
+		})
+	}
+}

--- a/internal/airplay/mirror.go
+++ b/internal/airplay/mirror.go
@@ -6,11 +6,13 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"log"
 	"math"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -252,6 +254,9 @@ func (c *AirPlayClient) setupMirrorSession(ctx context.Context, cfg StreamConfig
 	}
 
 	dbg("[SETUP] phase 1 (audio+session): ct=%d spf=%d audioFormat=0x%x controlPort=%d", audioCT, audioSPF, audioFmt, audioControlLPort)
+
+	debugDumpPlist("audio setup plist", audioSetupPlist)
+	debugDumpPlist("audio stream descriptor", audioStreamDesc)
 
 	audioSetupBody, err2 := plist.Marshal(audioSetupPlist, plist.BinaryFormat)
 	if err2 != nil {
@@ -1884,4 +1889,37 @@ func generateUUID() string {
 	b[8] = (b[8] & 0x3f) | 0x80 // Variant 10
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
 		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+// debugDumpPlist logs a plist map in a stable key order, summarising byte
+// slices by length and hex prefix. Lets the whole SETUP descriptor be diffed
+// between receiver configurations that accept it and ones that reject it.
+func debugDumpPlist(label string, m map[string]interface{}) {
+	if !DebugMode {
+		return
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	dbg("[SETUP] %s (%d keys):", label, len(keys))
+	for _, k := range keys {
+		switch v := m[k].(type) {
+		case []byte:
+			dbg("[SETUP]   %s = <%d bytes> %s", k, len(v), hex.EncodeToString(v[:min(len(v), 16)]))
+		case map[string]interface{}:
+			inner := make([]string, 0, len(v))
+			for ik := range v {
+				inner = append(inner, ik)
+			}
+			sort.Strings(inner)
+			dbg("[SETUP]   %s = map%v", k, inner)
+		case []interface{}:
+			dbg("[SETUP]   %s = list of %d", k, len(v))
+		default:
+			dbg("[SETUP]   %s = %v", k, v)
+		}
+	}
 }

--- a/man/man1/doubletake.1
+++ b/man/man1/doubletake.1
@@ -33,8 +33,13 @@ Connect to a specific Apple TV by IP address (skips mDNS discovery)
 .B \-port \fIPORT\fR
 AirPlay port (default: 7000)
 .TP
-.B \-pin \fIPIN\fR
-4-digit PIN for pairing
+.B \-code \fICODE\fR
+Pairing PIN shown on the receiver, or its configured password when
+"Require Password" is enabled. Prefer the
+.B DOUBLETAKE_CODE
+environment variable, which keeps the code out of shell history and
+.BR ps (1)
+output.
 .TP
 .B \-pair
 Force new pairing even if credentials exist
@@ -81,7 +86,10 @@ Connect to a specific Apple TV:
 .B doubletake \-target 192.168.1.77
 .TP
 Pair with a PIN (saves credentials for reuse):
-.B doubletake \-target 192.168.1.77 \-pair \-pin 1234
+.B doubletake \-target 192.168.1.77 \-pair \-code 1234
+.TP
+Connect to a receiver with "Require Password" enabled:
+.B DOUBLETAKE_CODE=... doubletake \-target 192.168.1.77
 .TP
 Stream with custom resolution and bitrate:
 .B doubletake \-target 192.168.1.77 \-width 1280 \-height 720 \-fps 30 \-bitrate 4500


### PR DESCRIPTION
Adds support for receivers with **Require Password** enabled (on an Apple TV:
Settings → AirPlay and HomeKit). Such a receiver challenges the mirroring
`SETUP` with HTTP Digest auth; nothing answered it, so mirroring failed with
`HTTP 401` and there was no way past it.

```sh
DOUBLETAKE_CODE='...' doubletake -target 192.168.1.77
```

### Commits

1. **Add AppleTV14,1 without Homepod to tested devices** — the configuration
   this was developed against.
2. **Fix PIN prompt for receivers that use a fixed password** — the prompt
   assumed an onscreen 4-digit code, and `fmt.Scanln` truncated anything with a
   space in it.
3. **airplay: log the SETUP plist under `-debug`** — dumps the SETUP descriptor
   in a stable key order so two runs can be diffed. This is what made the rest
   tractable.
4. **airplay: answer HTTP Digest challenges from password-protected receivers**
   — the fix itself.

Each builds and tests independently.

### Notes on the implementation

The challenge carries no `qop` or `algorithm`, so this is RFC 2069 digest:
`MD5(HA1:nonce:HA2)`. The retry lives inside `rtspRequest`/`httpRequest` rather
than at the ~24 call sites, so every request is covered uniformly and the
mirroring code is untouched by this PR. The nonce is cached on first sight, so
only the first request on a connection pays for a retry — a receiver that
challenges one request challenges them all.

The Digest username is fixed at `AirPlay`, matching the `realm="airplay"` that
mirroring receivers advertise. It is deliberately not configurable: the
challenge never carries a username and it is folded into HA1, so a wrong guess
is indistinguishable from a wrong password, and an option there would only
offer a second way to produce the same 401.

`-pin` is renamed to `-code` rather than adding a second flag beside it. The
two carry the same thing from the user's point of view — whatever the receiver
is asking for, an onscreen PIN or a configured password — and the receiver, not
the user, decides which it wants. **This PR adds no net new flags.**
`$DOUBLETAKE_CODE` is preferred and takes precedence, since a command line is
visible to other users in `ps` and lands in shell history.

One behaviour change worth flagging: a code no longer forces a full re-pair the
way `-pin` did. A password is needed on every session, so re-pairing each run
would discard working credentials. `-pair` still requests one explicitly.

### Verification

End to end against a password-protected AppleTV14,1 / tvOS 26.5
(AirTunes/950.7.1): full mirroring session, 13× 200, a single 401 (the expected
first challenge), no warnings. `realm="airplay"`, username `AirPlay`, `uri` as
the absolute request URI — a path-only `uri` is rejected with another 401.

Unit tests cover challenge parsing (including a real receiver nonce), the
digest computation against an independently-derived vector, the retry decision
table, and end-to-end cases against a fake receiver: a challenged request is
retried with credentials, a request with no password configured is not retried
at all, and later requests reuse the cached challenge instead of being
challenged again.

### Dropped after review

An earlier revision also advertised `timingProtocol=PTP` for pair-verified
sessions, on the theory that receivers reject the legacy NTP clock with a bare
`400`. @omarroth found the resulting stream stalled after the first frame, and
on re-testing I could not reproduce the `400` at all — the same receiver now
completes SETUP on NTP in 133 ms and streams cleanly. That commit is gone and
`timingProtocol` is back to plain NTP.
