### PR TITLE
Fix: accept alternative plist encoding for ReceiverInfo

### DIFF
--- a/internal/airplay/client.go
+++ b/internal/airplay/client.go
@@ -30,12 +30,12 @@ type ReceiverInfo struct {
 	SourceVersion     string        `plist:"sourceVersion"`
 	Features          uint64        `plist:"features"`
 	StatusFlags       uint64        `plist:"statusFlags"`
-	PK                []byte        `plist:"pk"`
+	PK                plistData     `plist:"pk"`
 	HasUDPMirror      bool          `plist:"hasUDPMirroringSupport"`
 	HDRCapability     string        `plist:"receiverHDRCapability"`
 	VolumeControlType int           `plist:"volumeControlType"`
 	InitialVolume     float64       `plist:"initialVolume"`
-	KeepAliveBody     bool          `plist:"keepAliveSendStatsAsBody"`
+	KeepAliveBody     plistFlag     `plist:"keepAliveSendStatsAsBody"`
 	PSI               string        `plist:"psi"`
 	PI                string        `plist:"pi"`
 	MacAddress        string        `plist:"macAddress"`
@@ -44,10 +44,10 @@ type ReceiverInfo struct {
 
 // DisplayInfo describes a receiver display advertised in the /info response.
 type DisplayInfo struct {
-	Width        int `plist:"width"`
-	Height       int `plist:"height"`
-	WidthPixels  int `plist:"widthPixels"`
-	HeightPixels int `plist:"heightPixels"`
+	Width        plistNumber `plist:"width"`
+	Height       plistNumber `plist:"height"`
+	WidthPixels  plistNumber `plist:"widthPixels"`
+	HeightPixels plistNumber `plist:"heightPixels"`
 }
 
 // DisplaySize returns the receiver's primary display resolution in pixels, or
@@ -66,7 +66,7 @@ func (i *ReceiverInfo) DisplaySize() (int, int) {
 	if w <= 0 || h <= 0 {
 		return 0, 0
 	}
-	return w, h
+	return int(w), int(h)
 }
 
 // HTTPStatusError is returned when a receiver responds with a non-2xx RTSP/HTTP status.

--- a/internal/airplay/plist_types.go
+++ b/internal/airplay/plist_types.go
@@ -1,0 +1,61 @@
+package airplay
+
+import (
+	"encoding/hex"
+	"fmt"
+)
+
+// data or hex string
+type plistData []byte
+
+func (d *plistData) UnmarshalPlist(unmarshal func(interface{}) error) error {
+	var data []byte
+	if unmarshal(&data) == nil {
+		*d = data
+		return nil
+	}
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return fmt.Errorf("expected data or hex string: %w", err)
+	}
+	*d = b
+	return nil
+}
+
+// integer or real
+type plistNumber int
+
+func (n *plistNumber) UnmarshalPlist(unmarshal func(interface{}) error) error {
+	var i int64
+	if unmarshal(&i) == nil {
+		*n = plistNumber(i)
+		return nil
+	}
+	var f float64
+	if err := unmarshal(&f); err != nil {
+		return err
+	}
+	*n = plistNumber(f)
+	return nil
+}
+
+// boolean or 0/1
+type plistFlag bool
+
+func (b *plistFlag) UnmarshalPlist(unmarshal func(interface{}) error) error {
+	var v bool
+	if unmarshal(&v) == nil {
+		*b = plistFlag(v)
+		return nil
+	}
+	var i int64
+	if err := unmarshal(&i); err != nil {
+		return err
+	}
+	*b = i != 0
+	return nil
+}

--- a/internal/airplay/plist_types_test.go
+++ b/internal/airplay/plist_types_test.go
@@ -1,0 +1,72 @@
+package airplay
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"howett.net/plist"
+)
+
+func decodeInfo(t *testing.T, info map[string]interface{}) ReceiverInfo {
+	t.Helper()
+	body, err := plist.Marshal(info, plist.BinaryFormat)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got ReceiverInfo
+	if _, err := plist.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return got
+}
+
+func TestReceiverInfoAcceptsEitherEncoding(t *testing.T) {
+	pk := make([]byte, 32)
+	for i := range pk {
+		pk[i] = byte(i)
+	}
+
+	strict := map[string]interface{}{
+		"pk":                       pk,
+		"keepAliveSendStatsAsBody": true,
+		"displays": []interface{}{map[string]interface{}{
+			"widthPixels": uint64(1920), "heightPixels": uint64(1080),
+		}},
+	}
+	loose := map[string]interface{}{
+		"pk":                       hex.EncodeToString(pk),
+		"keepAliveSendStatsAsBody": uint64(1),
+		"displays": []interface{}{map[string]interface{}{
+			"widthPixels": 1920.0, "heightPixels": 1080.0,
+		}},
+	}
+
+	for name, info := range map[string]map[string]interface{}{
+		"strict": strict,
+		"loose":  loose,
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := decodeInfo(t, info)
+			if hex.EncodeToString(got.PK) != hex.EncodeToString(pk) {
+				t.Errorf("PK = %x, want %x", got.PK, pk)
+			}
+			if !got.KeepAliveBody {
+				t.Error("KeepAliveBody = false, want true")
+			}
+			if w, h := got.DisplaySize(); w != 1920 || h != 1080 {
+				t.Errorf("DisplaySize() = %dx%d, want 1920x1080", w, h)
+			}
+		})
+	}
+}
+
+func TestReceiverInfoRejectsUndecodablePK(t *testing.T) {
+	body, err := plist.Marshal(map[string]interface{}{"pk": "not hex"}, plist.BinaryFormat)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got ReceiverInfo
+	if _, err := plist.Unmarshal(body, &got); err == nil {
+		t.Fatal("expected an error for a pk that is neither data nor hex")
+	}
+}


### PR DESCRIPTION
This PR allows doubletake to additionally work with some legacy first-party and third-party AirPlay receivers that use an alternative plist encoding.

Before this fix, `GetInfo` would fail outright on `/info` responses that Apple's own sender accepts, so connection dies before pairing. Two of the affected receivers can be tested relatively easily,

[AirServer](https://www.airserver.com/) (AirTunes/220.68, AppleTV5,3) sends `pk` as a 64-character hex string and the display dimensions as reals, `displays[0].widthPixels`: `1920.0`, `displays[0].heightPixels`: `1080.0`, which results in
```
decode info plist: plist: type mismatch: tried to decode plist type `string' into value of type `[]uint8'
decode info plist: plist: type mismatch: tried to decode plist type `real' into value of type `int'
```

[Reflector](https://www.airsquirrels.com/reflector) (AirTunes/230.33) sends `keepAliveSendStatsAsBody` as integer `1`, which results in
```
decode info plist: plist: type mismatch: tried to decode plist type `integer' into value of type `bool'
```

Receivers were written against senders that read `/info` through CoreFoundation, where `CFNumber` draws no integer/real distinction and `CFBoolean` is interchangeable with a 0/1 `CFNumber`. Decoding into Go's `int`/`bool` is stricter than the wire format, and since `plist.Unmarshal` aborts on the first mismatch, one loosely typed field takes the whole response with it. This PR fixes this issue, and is currently applied [here](https://github.com/jqssun/android-display-mirror).
