### PR TITLE
Support third-party HAP TVs that advertise PTP (LG 75UP75009LC)

### DIFF
--- a/internal/airplay/client.go
+++ b/internal/airplay/client.go
@@ -42,6 +42,7 @@ type ReceiverInfo struct {
 	PI                string        `plist:"pi"`
 	MacAddress        string        `plist:"macAddress"`
 	Displays          []DisplayInfo `plist:"displays"`
+	hasPTPInfo        bool
 }
 
 // AirPlay receiver status flags used to choose one authentication prompt.
@@ -281,7 +282,7 @@ func (c *AirPlayClient) GetInfo() (*ReceiverInfo, error) {
 			}
 			return keys
 		}())
-		for _, key := range []string{"audioFormats", "audioLatencies", "displays", "features", "statusFlags", "initialVolume", "volumeControlType", "keepAliveSendStatsAsBody", "supportedAudioFormatsExtended", "supportedFormats"} {
+		for _, key := range []string{"audioFormats", "audioLatencies", "displays", "features", "statusFlags", "initialVolume", "volumeControlType", "keepAliveSendStatsAsBody", "supportedAudioFormatsExtended", "supportedFormats", "PTPInfo"} {
 			if v, ok := fullInfo[key]; ok {
 				dbg("[INFO] %s: %+v", key, v)
 			}
@@ -291,6 +292,9 @@ func (c *AirPlayClient) GetInfo() (*ReceiverInfo, error) {
 	var info ReceiverInfo
 	if _, err := plist.Unmarshal(resp, &info); err != nil {
 		return nil, fmt.Errorf("decode info plist: %w", err)
+	}
+	if _, ok := fullInfo["PTPInfo"]; ok {
+		info.hasPTPInfo = true
 	}
 	c.info = &info
 	return &info, nil

--- a/internal/airplay/mirror.go
+++ b/internal/airplay/mirror.go
@@ -135,6 +135,10 @@ type MirrorSession struct {
 }
 
 func selectAudioSecurityMode(encrypted bool) audioSecurityMode {
+	// Encrypted pair-verify sessions (Apple and third-party HAP) encrypt audio
+	// with a stream key advertised as shk. FairPlay ekey is a separate path and
+	// is not available on TVs that omit FPSAP. The SETUP *shape* (controlPort
+	// vs streamConnections) is chosen later from usesModernSessionSetup().
 	if encrypted {
 		return audioSecurityChaCha
 	}
@@ -150,6 +154,17 @@ func sourceVersionForSession(modern bool) string {
 
 func timingProtocolForSession(modern bool) string {
 	if modern {
+		return timingProtocolPTP
+	}
+	return timingProtocolNTP
+}
+
+func (i *ReceiverInfo) advertisesPTP() bool {
+	return i != nil && i.hasPTPInfo
+}
+
+func timingProtocolForClient(c *AirPlayClient, modern bool) string {
+	if modern || c != nil && c.info.advertisesPTP() {
 		return timingProtocolPTP
 	}
 	return timingProtocolNTP
@@ -240,7 +255,7 @@ func (c *AirPlayClient) setupMirrorSession(ctx context.Context, cfg StreamConfig
 	senderName := pairingClientName()
 	modernSession := c.usesModernSessionSetup()
 	sourceVersion := sourceVersionForSession(modernSession)
-	timingProtocol := timingProtocolForSession(modernSession)
+	timingProtocol := timingProtocolForClient(c, modernSession)
 	var clock *mediaClock
 	if timingProtocol == timingProtocolPTP {
 		clock = &mediaClock{}
@@ -475,13 +490,19 @@ func (c *AirPlayClient) setupMirrorSession(ctx context.Context, cfg StreamConfig
 		audioStreamDesc["redundantAudio"] = int64(2)
 	}
 
-	// Modern HAP receivers look for shk on the audio stream descriptor.
-	modernAudio := audioMode == audioSecurityChaCha && len(audioChaChaKey) == 32
+	// Modern Apple SETUP replaces controlPort with streamConnections.
+	// Third-party HAP TVs accepted PTP + controlPort; they still need shk or
+	// they silently drop plaintext ALAC.
+	modernAudio := modernSession && audioMode == audioSecurityChaCha && len(audioChaChaKey) == 32
 	if modernAudio {
 		addModernScreenAudioStreamFields(audioStreamDesc, audioChaChaKey, audioControlLPort)
 		dbg("[SETUP] audio stream descriptor includes shk (%d bytes)", len(audioChaChaKey))
 	} else {
 		audioStreamDesc["controlPort"] = int64(audioControlLPort)
+		if audioMode == audioSecurityChaCha && len(audioChaChaKey) == 32 {
+			audioStreamDesc["shk"] = audioChaChaKey
+			dbg("[SETUP] audio stream descriptor includes shk (%d bytes) with legacy controlPort", len(audioChaChaKey))
+		}
 	}
 	var audioSetupPlist map[string]interface{}
 	if modernControlSetup {
@@ -517,7 +538,9 @@ func (c *AirPlayClient) setupMirrorSession(ctx context.Context, cfg StreamConfig
 		skipRecord, _ = audioResp["skipRecord"].(bool)
 		if timingProtocol == timingProtocolPTP {
 			if err := clock.configureFromSetup(audioResp, audioRespHeaders, audioRespReceivedAt); err != nil {
-				return nil, fmt.Errorf("configure PTP media clock: %w", err)
+				// Third-party TVs advertise PTPInfo but often omit Apple clock
+				// headers. Keep the session; frames fall back to local time.
+				dbg("[PTP] %v; using local timestamps", err)
 			}
 		}
 		receiverEventPort = plistInt(audioResp["eventPort"])

--- a/internal/airplay/mirror_clock_test.go
+++ b/internal/airplay/mirror_clock_test.go
@@ -218,6 +218,20 @@ func TestTimingProtocolForSession(t *testing.T) {
 	}
 }
 
+func TestTimingProtocolForClientUsesAdvertisedPTP(t *testing.T) {
+	legacy := &AirPlayClient{info: &ReceiverInfo{}}
+	if got := timingProtocolForClient(legacy, false); got != timingProtocolNTP {
+		t.Fatalf("legacy without PTPInfo = %q, want NTP", got)
+	}
+	ptpTV := &AirPlayClient{info: &ReceiverInfo{hasPTPInfo: true}}
+	if got := timingProtocolForClient(ptpTV, false); got != timingProtocolPTP {
+		t.Fatalf("third-party with PTPInfo = %q, want PTP", got)
+	}
+	if got := timingProtocolForClient(&AirPlayClient{info: &ReceiverInfo{hasPTPInfo: true}}, true); got != timingProtocolPTP {
+		t.Fatalf("modern + PTPInfo = %q, want PTP", got)
+	}
+}
+
 func TestModernSessionSetupRequiresFirstPartyProfile(t *testing.T) {
 	const rokuFeatures = uint64(0x38bcf46007f8ad0)
 

--- a/internal/airplay/mirror_setup_test.go
+++ b/internal/airplay/mirror_setup_test.go
@@ -22,6 +22,15 @@ type rtspTestRequest struct {
 	headers map[string]string
 }
 
+func TestSelectAudioSecurityMode(t *testing.T) {
+	if got := selectAudioSecurityMode(false); got != audioSecurityLegacyAES {
+		t.Fatalf("plaintext session audio mode = %v, want AES/legacy", got)
+	}
+	if got := selectAudioSecurityMode(true); got != audioSecurityChaCha {
+		t.Fatalf("encrypted HAP session audio mode = %v, want ChaCha", got)
+	}
+}
+
 func TestSourceVersionForSession(t *testing.T) {
 	if got := sourceVersionForSession(false); got != legacyAirPlaySourceVersion {
 		t.Fatalf("legacy source version = %q, want %q", got, legacyAirPlaySourceVersion)


### PR DESCRIPTION
### Summary
Pairing and video SETUP failed on an LG webOS AirPlay receiver (`AirTunes/377.25.06`, `features=0x38bcb46007f8ad0`). Pair-verify succeeded; audio SETUP waited ~20s and returned `400`. After using PTP, video worked but audio was silent.

The TV is classified as third-party (not modern Apple), so we used NTP + a combined audio SETUP. It advertises `PTPInfo` and never sends an NTP probe (same as iPhone/Mac on that LAN). After PTP, audio was still sent in the clear because there is no FairPlay SAP; the TV drops that.

### Changes
- Record `PTPInfo` from `/info` and select **PTP** independently of `usesModernSessionSetup()`.
- Keep **legacy SETUP** (`sourceVersion=280.33`, `controlPort`, no control-only first SETUP).
- On encrypted pair-verify sessions, put a **32-byte ChaCha `shk`** on the audio stream even when `controlPort` is still used.
- If PTP clock headers are missing, log and continue instead of failing SETUP.

### Tested
- LG `75UP75009LC`: pairing, video, and audio.
- `go test ./internal/airplay/`
