### PR TITLE
Don't change the receiver's volume when audio is disabled

### DIFF
--- a/internal/airplay/mirror.go
+++ b/internal/airplay/mirror.go
@@ -642,17 +642,27 @@ func (c *AirPlayClient) setupMirrorSession(ctx context.Context, cfg StreamConfig
 		}
 	}
 
-	// Set volume to 0 dB (full scale). Positive dB values are invalid here and
-	// current receivers may interpret them as zero gain.
-	volumeBody := audioVolumeBody(false)
-	_, _, err = c.rtspRequest("SET_PARAMETER", audioURI, "text/parameters", volumeBody, nil)
-	if err != nil {
-		dbg("[SETUP] SET_PARAMETER volume failed (non-fatal): %v", err)
+	// Only set the receiver's volume when this session actually carries audio.
+	// `volume: 0.000000` is 0 dB — full scale in AirPlay, not silence — so a
+	// video-only session would force the receiver to maximum on every connect.
+	// Sending -144 instead would be equally destructive of the user's setting;
+	// a session that transmits no audio has no use for the receiver's audio
+	// state and should leave its volume untouched.
+	if cfg.NoAudio {
+		dbg("[SETUP] no-audio session: skipping SET_PARAMETER volume")
 	} else {
-		dbg("[SETUP] SET_PARAMETER volume=0 sent")
+		// Positive dB values are invalid here and current receivers may
+		// interpret them as zero gain. Real senders send the sender's own
+		// slider value; 0 dB is this sender's fixed choice.
+		volumeBody := audioVolumeBody(false)
+		if _, _, err := c.rtspRequest("SET_PARAMETER", audioURI, "text/parameters", volumeBody, nil); err != nil {
+			dbg("[SETUP] SET_PARAMETER volume failed (non-fatal): %v", err)
+		} else {
+			dbg("[SETUP] SET_PARAMETER volume=0 sent")
+		}
+		// Send volume twice (pcap shows real senders do this)
+		_, _, _ = c.rtspRequest("SET_PARAMETER", audioURI, "text/parameters", volumeBody, nil)
 	}
-	// Send volume twice (pcap shows real senders do this)
-	_, _, _ = c.rtspRequest("SET_PARAMETER", audioURI, "text/parameters", volumeBody, nil)
 
 	if timingProtocol == timingProtocolPTP {
 		// PTP uses the receiver's fixed 319/320 ports. The first socket was only
@@ -1740,6 +1750,14 @@ func (s *MirrorSession) HasAudio() bool {
 func (s *MirrorSession) SetAudioMuted(muted bool) error {
 	if s == nil || s.client == nil || s.sessionURI == "" {
 		return fmt.Errorf("audio control unavailable")
+	}
+	// A session started with audio disabled must not write the receiver's
+	// volume either: unmuting sends 0 dB — full scale — which would discard
+	// whatever the user had set, exactly as the setup path once did. The
+	// session negotiates an audio stream even in this mode, so HasAudio() is
+	// not sufficient to tell the two apart.
+	if s.noAudio {
+		return fmt.Errorf("audio control unavailable: session was started with audio disabled")
 	}
 
 	if _, _, err := s.client.rtspRequest("SET_PARAMETER", s.sessionURI, "text/parameters", audioVolumeBody(muted), nil); err != nil {

--- a/internal/airplay/mirror_setup_test.go
+++ b/internal/airplay/mirror_setup_test.go
@@ -201,12 +201,52 @@ func TestSetupMirrorNoAudioStillNegotiatesAudioSession(t *testing.T) {
 		{name: "skip record", skipRecord: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			testSetupMirrorNoAudioStillNegotiatesAudioSession(t, test.skipRecord)
+			testSetupMirrorAudioSessionNegotiation(t, audioSessionCase{skipRecord: test.skipRecord, noAudio: true})
 		})
 	}
 }
 
-func testSetupMirrorNoAudioStillNegotiatesAudioSession(t *testing.T, skipRecord bool) {
+// A session that DOES carry audio must still set the receiver's volume, so the
+// -no-audio guard narrows that behaviour rather than removing it.
+func TestSetupMirrorWithAudioSetsReceiverVolume(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		skipRecord bool
+	}{
+		{name: "record", skipRecord: false},
+		{name: "skip record", skipRecord: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			testSetupMirrorAudioSessionNegotiation(t, audioSessionCase{skipRecord: test.skipRecord, noAudio: false})
+		})
+	}
+}
+
+// A no-audio session must not be able to write the receiver's volume through
+// the daemon's mute control either: unmuting sends 0 dB, which is full scale.
+func TestSetAudioMutedRefusesWhenSessionHasNoAudio(t *testing.T) {
+	for _, muted := range []bool{true, false} {
+		session := &MirrorSession{client: &AirPlayClient{}, sessionURI: "rtsp://example/session", noAudio: true}
+		err := session.SetAudioMuted(muted)
+		if err == nil {
+			t.Fatalf("SetAudioMuted(%v) = nil, want a refusal for a no-audio session", muted)
+		}
+		// Assert the REASON, not merely that something failed: without the
+		// guard this call still errors (no connection), so an error alone
+		// would pass on the unfixed code.
+		if !strings.Contains(err.Error(), "audio disabled") {
+			t.Fatalf("SetAudioMuted(%v) error = %q, want a refusal naming the disabled audio", muted, err)
+		}
+	}
+}
+
+type audioSessionCase struct {
+	skipRecord bool
+	noAudio    bool
+}
+
+func testSetupMirrorAudioSessionNegotiation(t *testing.T, test audioSessionCase) {
+	skipRecord, noAudio := test.skipRecord, test.noAudio
 	eventListener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen event channel: %v", err)
@@ -448,12 +488,12 @@ func testSetupMirrorNoAudioStillNegotiatesAudioSession(t *testing.T, skipRecord 
 	}
 	defer client.Close()
 
-	session, err := client.SetupMirror(ctx, StreamConfig{FPS: 30, NoAudio: true})
+	session, err := client.SetupMirror(ctx, StreamConfig{FPS: 30, NoAudio: noAudio})
 	if err != nil {
-		t.Fatalf("SetupMirror(no audio): %v", err)
+		t.Fatalf("SetupMirror(noAudio=%v): %v", noAudio, err)
 	}
 	if !session.HasAudio() {
-		t.Fatal("expected no-audio session setup to keep the negotiated audio stream state")
+		t.Fatalf("noAudio=%v: expected the negotiated audio stream state to survive setup", noAudio)
 	}
 	if !skipRecord && session.timestampBias != 250*time.Millisecond {
 		t.Fatalf("session timestamp bias = %v, want RECORD Audio-Latency of 250ms", session.timestampBias)
@@ -488,7 +528,13 @@ func testSetupMirrorNoAudioStillNegotiatesAudioSession(t *testing.T, skipRecord 
 		recordIndex = len(wantMethods)
 		wantMethods = append(wantMethods, "RECORD")
 	}
-	wantMethods = append(wantMethods, "SET_PARAMETER", "SET_PARAMETER", "POST", "TEARDOWN")
+	// The two volume SET_PARAMETERs are sent only when the session carries
+	// audio: `volume: 0.000000` is 0 dB — full scale — so a video-only
+	// session would force the receiver to maximum.
+	if !noAudio {
+		wantMethods = append(wantMethods, "SET_PARAMETER", "SET_PARAMETER")
+	}
+	wantMethods = append(wantMethods, "POST", "TEARDOWN")
 	got := make([]rtspTestRequest, 0, len(wantMethods))
 	for range wantMethods {
 		select {


### PR DESCRIPTION
## The bug

`-no-audio` sets the receiver's volume to maximum on every connect.

`volume: 0.000000` is 0 dB, which is full scale. `setupMirrorSession` sends it unconditionally, twice, so a session that streams no audio at all still commands the receiver to maximum and discards whatever the user had set. Reconnecting a dashboard or a mirrored window resets a TV's volume to 100 each time.

## Not the same as #11

I want to be clear about this up front, because #11 set `volume: 20.000000` and `5f14b6f` reverted it — correctly. Positive dB is out of range and receivers may read it as zero gain, so picking a quieter number is not a fix.

This PR does not pick a number. It declines to send a volume at all when the session carries no audio. When audio *is* enabled, the 0 dB behaviour from `5f14b6f` is untouched.

## Also: the daemon's mute control

`SetAudioMuted` has the same effect one click away, and it is reachable in exactly the case this PR is about.

`daemon.go` deliberately routes mute/unmute to the receiver when audio is disabled:

```go
if t.session != nil && (d.cfg.NoAudio || t.session.HasAudio()) {
```

and unmuting sends `audioVolumeBody(false)` — the identical full-scale value. A no-audio session still negotiates an audio stream, so `HasAudio()` is true and the plasmoid offers a mute toggle for a video-only session: first press silences the receiver, next press sets it to maximum.

So `HasAudio()` cannot distinguish the two modes. The guard reads `MirrorSession.noAudio`, which until now was assigned and never read.

## Why skipping is safe

A session that transmits no audio has no use for the receiver's audio state. The request also sits after `RECORD`, so it is not part of the handshake, and this repo's own receiver treats `SET_PARAMETER` as a bare OK with no state transition.

I considered echoing the receiver's own reported volume back instead. On the Roku Streambar Pro I tested, `initialVolume` from `/info` stayed at `0.0` across ten VolumeDown and six VolumeUp presses, so it does not track that receiver's current volume and sending it back would still command full scale. Other receivers may report it faithfully — I only have the one device, so I did not build on it.

## Tests

`TestSetupMirrorNoAudioStillNegotiatesAudioSession` asserted the two volume `SET_PARAMETER`s as part of the expected RTSP sequence for a no-audio session, and it was the only test covering that sequence — so updating it alone would have left nothing asserting that audio sessions still set the volume.

The shared helper is now parameterized over `noAudio`, with a named test per direction, plus one for the mute guard.

Each was checked against a mutation rather than just observed green:

- revert the setup guard → the no-audio test fails
- make the skip unconditional → the with-audio test fails
- invert the condition → both fail
- remove the `SetAudioMuted` guard → the mute test fails

Worth noting for anyone touching that harness: what actually pins the `volume: 0.000000` payload is the fake receiver's body check, not the method sequence, and a mismatch there surfaces as a 5-second `/feedback` timeout rather than a useful message.

`gofmt`, `go vet` and `go test ./...` are clean, verified on a clean checkout of the commit rather than a working tree.

## Verified on hardware

Roku Streambar Pro, model 9101R2:

```
-no-audio    [SETUP] no-audio session: skipping SET_PARAMETER volume
with audio   [SETUP] SET_PARAMETER volume=0 sent
```

Volume left untouched in the first case, unchanged behaviour in the second.

## Scope

I deliberately did not touch the plasmoid, which still shows a mute toggle for video-only sessions — it now fails with a clear error instead of changing the volume. Hiding the control would mean changing what `has_audio` reports, which felt like a bigger decision than this fix. Happy to follow up if you'd prefer it gone.
