### PR TITLE
Add opt-in portal resize for fractional Wayland scaling

### DIFF
--- a/cmd/doubletake/main.go
+++ b/cmd/doubletake/main.go
@@ -80,6 +80,7 @@ func main() {
 	x11WindowID := flag.String("x11-window-id", "", "X11 window id to capture, decimal or 0xhex")
 	x11WindowName := flag.String("x11-window-name", "", "X11 window name to capture; prefer -x11-window-id")
 	noCursor := flag.Bool("no-cursor", false, "Don't show the mouse cursor in the captured video")
+	portalResize := flag.Bool("portal-resize", false, "Resize the captured frame to the size the screencast portal reported, using vapostproc. Needed on fractionally scaled outputs, which are otherwise cropped to the top-left corner")
 	flag.Parse()
 	if err := airplay.ValidateHWAccel(*hwaccel); err != nil {
 		log.Fatalf("invalid -hwaccel: %v", err)
@@ -346,6 +347,7 @@ func main() {
 		X11WindowID:   xid,
 		X11WindowName: *x11WindowName,
 		ShowCursor:    !*noCursor,
+		PortalResize:  *portalResize,
 	}
 	var capturePreparation *airplay.CapturePreparation
 	if *testMode {

--- a/internal/airplay/capture.go
+++ b/internal/airplay/capture.go
@@ -37,6 +37,9 @@ type CaptureConfig struct {
 
 	ShowCursor bool // show the mouse cursor in the captured video (Wayland and X11)
 
+	// PortalResize fits the captured frame to the size the portal reported.
+	PortalResize bool
+
 	RestoreToken     string
 	SaveRestoreToken func(string) error
 }
@@ -860,8 +863,20 @@ func startPreparedWaylandCapture(ctx context.Context, cfg CaptureConfig, encoder
 	var beforeConvert []gstStage
 	if hasGstElement("vapostproc") {
 		beforeConvert = append(beforeConvert, gstStage{"vapostproc"})
+		// Fractional Wayland scaling makes the portal report logical dimensions
+		// while PipeWire delivers physical buffers. The portal exposes no physical
+		// size, so request the reported caps unconditionally; vapostproc negotiates
+		// passthrough when they already match. Keep this on the GPU path because
+		// software scaling would penalize systems without GPU processing.
+		if hasCompositor && cfg.PortalResize {
+			beforeConvert = append(beforeConvert,
+				gstStage{fmt.Sprintf("video/x-raw,width=%d,height=%d", streamSize[0], streamSize[1])})
+		}
 	} else {
 		log.Printf("[CAPTURE] vapostproc unavailable, using software conversion")
+		if cfg.PortalResize {
+			log.Printf("[CAPTURE] -portal-resize applies to the vapostproc path only and is inactive")
+		}
 	}
 
 	var afterScale []gstStage


### PR DESCRIPTION
## Summary

This fixes cropped screen mirroring on fractionally scaled Wayland
outputs.

The ScreenCast portal reports the output's logical size, while PipeWire
delivers a physical-size buffer. For example, a 2560x1600 panel at 166%
scale is reported as 1536x960, but the stream carries 3072x1920 frames.
The pipeline pins the compositor output to 1536x960, and the compositor
places its input at 0,0 without scaling it. The result is the top-left
1536x960 portion of the frame rather than the full desktop.

The new `-portal-resize` option adds a caps filter after `vapostproc`,
fitting the frame to the portal-reported canvas on the GPU before it
reaches the compositor.

The portal does not provide the physical buffer size, so the target caps
are requested unconditionally when the option is enabled. This is safe
when the dimensions already match because `vapostproc` negotiates
passthrough.

## Performance

These measurements processed 600 buffers, with two runs per case:

| Pipeline | Run 1 | Run 2 |
|---|---:|---:|
| 1536x960 to `fakesink`, no `vapostproc` | 1.79 s | 1.76 s |
| 1536x960 through `vapostproc` to 1536x960 | 1.72 s | 1.73 s |
| 3072x1920 to `fakesink`, no `vapostproc` | 7.39 s | 7.36 s |
| 3072x1920 through `vapostproc` to 1536x960 | 6.97 s | 6.96 s |

The matching-size case confirms that `vapostproc` passes the frame
through. The cost of the real resize is below the measurement noise.

Only the `vapostproc` path is fitted. Adding the same operation to the
software path would impose another scale on the systems least able to
absorb it. If `vapostproc` is unavailable, the option logs that it is
inactive and preserves the existing cropped behavior.

I also tried removing the compositor caps pin and allowing the physical
frame to reach the existing software `videoconvert` and `videoscale`.
That fixed the crop, but the 10-bit pipeline could not sustain 30 fps at
the physical resolution. Source age passed 1.7 seconds and continued to
rise while presentation slack became steadily more negative.

## Verification

I tested against an Apple TV 4K (AppleTV14,1) running tvOS 26.6. The
full desktop was visible with the correct aspect ratio, source age
remained between 35 and 50 ms with positive presentation slack, and the
stream stayed stable for several minutes.

The sender was running GNOME 50.1 on Wayland at 166% scaling, GStreamer
1.28.2, Mesa radeonsi on a Radeon 860M, and NVENC HEVC on an RTX 5070.

`go test ./...` passes.

The option is off by default. I am happy to make it the default if you
prefer.
