### PR TITLE
Use NTP for Samsung AU9000 running AirPlay 377.25.06

### DIFF
--- a/internal/airplay/compatibility.go
+++ b/internal/airplay/compatibility.go
@@ -85,6 +85,12 @@ func compatibilityForReceiver(info *ReceiverInfo, encrypted, audioEnabled bool) 
 	// mirroring session.
 	if encrypted && info.HasFeature(featurePTP) && supportsPTPSourceVersion(info.SourceVersion) {
 		policy.timing = timingProtocolPTP
+		// Samsung AU9000 with this AirPlay version advertises PTP but omits
+		// timingPeerInfo.ClockID in SETUP. NTP works on the same receiver.
+		// Keep the exception limited to the observed model/version pair.
+		if info.Model == "UAU9000" && info.SourceVersion == "377.25.06" {
+			policy.timing = timingProtocolNTP
+		}
 	}
 
 	return policy, nil

--- a/internal/airplay/compatibility_test.go
+++ b/internal/airplay/compatibility_test.go
@@ -259,3 +259,30 @@ func TestHybridAudioDescriptorLayouts(t *testing.T) {
 		t.Fatalf("plaintext streamConnections encryption flag = %#v, want false", rtp["streamConnectionKeyUseStreamEncryptionKey"])
 	}
 }
+
+func TestSamsungAU9000TimingException(t *testing.T) {
+	for _, test := range []struct {
+		name, model, version, want string
+	}{
+		{"observed receiver", "UAU9000", "377.25.06", timingProtocolNTP},
+		{"different model", "another model", "377.25.06", timingProtocolPTP},
+		{"missing model", "", "377.25.06", timingProtocolPTP},
+		{"different version", "UAU9000", "377.25.07", timingProtocolPTP},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			info := receiverWithFeatures(featurePTP, featureAudioStreamConnectionSetup)
+			info.SourceVersion = test.version
+			baseline := mustCompatibility(t, &info, true)
+			info.Model = test.model
+			got := mustCompatibility(t, &info, true)
+			if got.timing != test.want {
+				t.Fatalf("timing = %q, want %q", got.timing, test.want)
+			}
+			// The quirk must not change audio negotiation or key placement.
+			got.timing = baseline.timing
+			if !reflect.DeepEqual(got, baseline) {
+				t.Fatalf("timing exception changed another policy field: got %+v, want %+v", got, baseline)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This receiver advertises PTP support, but its SETUP response omits `timingPeerInfo.ClockID`. Doubletake consequently fails before streaming starts.

Select NTP for this specific model and AirPlay version. Other receivers retain the existing timing policy (it can be expanded as needed, but I'd rather be specific here since I don't have any other receivers to test it with).

Desktop mirroring was verified through the CLI on a Samsung AU9000 in conjunction with #43. Tests cover the exception, neighbouring model/version combinations, and unchanged audio negotiation. `go test ./...` passes.
